### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ catkin_package(
     DEPENDS
 )
 ```
+```txt
+add_dependencies(<your executable> ascend_msgs_generate_messages_cpp)
+```
+
 Include the messages in your source code, i.e.
 ```cpp
 #include <ascend_msgs/LineCounter.h>


### PR DESCRIPTION
`ascend_msgs_generate_messages_cpp` must be declared as a dependency to make sure that the messages are build before the executable