### PR TITLE
Include reward with action

### DIFF
--- a/action/ControlFSM.action
+++ b/action/ControlFSM.action
@@ -17,8 +17,6 @@ int8 cmd #Action type
 int8 target_id
 int8 caller_id
 ---
-#Result
-bool finished
 ---
 #Progress
 float32 vel_estimate

--- a/action/ControlFSM.action
+++ b/action/ControlFSM.action
@@ -17,6 +17,7 @@ int8 cmd #Action type
 int8 target_id
 int8 caller_id
 ---
+# Result is intentionally left blank as it was not used
 ---
 #Progress
 float32 vel_estimate

--- a/action/ControlFSM.action
+++ b/action/ControlFSM.action
@@ -17,7 +17,7 @@ int8 cmd #Action type
 int8 target_id
 int8 caller_id
 ---
-# Result is intentionally left blank as it was not used
+# Result is intentionally left blank as it was not used. ActionLib informs us if action succeded or was aborted.
 ---
 #Progress
 float32 vel_estimate

--- a/action/ControlFSM.action
+++ b/action/ControlFSM.action
@@ -12,6 +12,7 @@ int8 CALLER_DEBUGGER = 51
 float32 x
 float32 y
 float32 z
+float32 reward
 int8 cmd #Action type
 int8 target_id
 int8 caller_id


### PR DESCRIPTION
The ai-sim needs to be passed our calculated action reward to
properly show informational messages. This can be ignored of
other nodes does not want to use it.