### PR TITLE
ObstacleBoundingBoxes message for collision detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_message_files(
    AIWorldObservation.msg
    PointArrayStamped.msg
    LandDetector.msg
+   ObstacleBoundingBoxes.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/msg/ObstacleBoundingBoxes.msg
+++ b/msg/ObstacleBoundingBoxes.msg
@@ -1,0 +1,5 @@
+Header header
+
+std_msgs/MultiArrayDimension layout   # Layout of point-array
+geometry_msgs/Point32[] points        # Actual data-points, (min_pt, max_pt)
+float32[] distances                   # distances to each box, index corresponding to points


### PR DESCRIPTION
Used by the immediate collision detection to publish bounding boxes of obstacles and distances to them. 